### PR TITLE
Removed babel dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,16 @@
   "description": "Getting started with React and Mocha",
   "main": "index.html",
   "devDependencies": {
-    "babel": "^6.1.18",
-    "babel-core": "^6.2.1",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
-    "babelify": "^7.2.0",
     "jsdom": "^7.0.2",
     "mocha": "^2.3.4",
     "mocha-jsdom": "^1.0.0",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "react-tools": "^0.13.3"
   },
   "scripts": {
-    "test": "mocha test/**/*-test.js --compilers js:babel-core/register --recursive"
+    "test": "mocha --compilers .:test/compiler.js test/**/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -1,0 +1,14 @@
+// tests/compiler.js
+var fs = require('fs'),
+  ReactTools = require('react-tools'),
+  origJs = require.extensions['.js'];
+
+require.extensions['.js'] = function(module, filename) {
+  // optimization: external code never needs compilation.
+  if (filename.indexOf('node_modules/') >= 0) {
+    return (origJs || require.extensions['.js'])(module, filename);
+  }
+  var content = fs.readFileSync(filename, 'utf8');
+  var compiled = ReactTools.transform(content, {harmony: true});
+  return module._compile(compiled, filename);
+};


### PR DESCRIPTION
This commit officially work without the babel dependency. However
after doing some digging and researching, I came to the realization
that babel may just need to stay.

The new compiler uses the NPM package react-tools. When installing that
you get a deprecation warning with a link to a blog article
(https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html)
on what is going on. The blog basically says that React as a team, on Jun 12, 2015,
made the decision to work with the babel team and begin to utilize babel
as their standard build system.

Babel replaces Facebook's JSTransform, the source transformation tool
that they wrote in-house. However due to increasing demand Facebook was
just not able to keep JSTransform up to date, so they decided to utilize
another teams build system and let the babel team worry about bringing
in new JavaScript language features. Good for them, smart move in my
opinion.

It is sad though that in order to run babel you have to include five NPM
packages.

Oh well, I guess it is what it is.